### PR TITLE
Add Years Validator

### DIFF
--- a/config/validator/validation.yaml
+++ b/config/validator/validation.yaml
@@ -1,0 +1,8 @@
+App\Entity\Books:
+    properties:
+        release_year:
+            - NotBlank: ~
+        title:
+            - NotBlank: ~
+        author:
+            - NotBlank: ~

--- a/src/Validator/Constraints/ValidYear.php
+++ b/src/Validator/Constraints/ValidYear.php
@@ -1,0 +1,12 @@
+<?php
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Class ValidYear
+ */
+class ValidYear extends Constraint
+{
+    public $message = 'This is not a valid year.';
+}

--- a/src/Validator/Constraints/ValidYearValidator.php
+++ b/src/Validator/Constraints/ValidYearValidator.php
@@ -1,0 +1,22 @@
+<?php
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Class ValidYearValidator
+ */
+class ValidYearValidator extends ConstraintValidator
+{
+    /**
+     * @param mixed $value
+     * @param Constraint $constraint
+     */
+    public function validate(mixed $value, Constraint $constraint)
+    {
+        if (!checkdate(1, 1, $value)) {
+            $this->context->buildViolation($constraint->message)->addViolation();
+        }
+    }
+}


### PR DESCRIPTION
Since I use the smallint data type for the release_year field in MySQL in need to verify this number before setting into DB.
I had to create a new validator 'cause if I'd use the default range validator it wouldn't work the next year.